### PR TITLE
Narrowed inbound firewall rules and added webserver tag to droplet

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,13 @@ Similarly, a PAT needs to be created on DO for connecting to the API. This can b
     do_token = "[personal_access_token]"
 ```
 
+Now that there is an access mechanism, you need to specify the specific IP addresses that you want to have access the machine. This is done by adding the specific IP addresses to the `terraform.tfvars` file. In this case, there are two: one is the IP address of your home network, and the other belongs to a static IP address provided by a VPN provider (for those times when you're working remotely outside of your home network). If you don't have a static IP address from a VPN provider, just use the one associated with your home network:
+
+```hcl
+    inbound_home_ip: "[home_ip4_address]"
+    inbound_static_ip: "[static_ip4_address]"
+```
+
 Note that the `terraform.tfvars` file does not exist in the repository. This file is protected from version control with `.gitignore`. This file needs to be created in the project's root directory, and the above values should be placed inside it.
 
 ---

--- a/terraform/resources.tf
+++ b/terraform/resources.tf
@@ -10,6 +10,9 @@ resource "digitalocean_droplet" "tyr_server" {
   ssh_keys = [
     data.digitalocean_ssh_key.pixelbook.id,
   ]
+  tags = [
+    "webserver"
+  ]
 }
 
 resource "digitalocean_firewall" "tyr_firewall" {
@@ -18,12 +21,18 @@ resource "digitalocean_firewall" "tyr_firewall" {
   inbound_rule {
     protocol         = "tcp"
     port_range       = "22"
-    source_addresses = ["0.0.0.0/0", "::/0"]
+    source_addresses = [
+      var.inbound_home_ip,
+      var.inbound_static_ip
+    ]
   }
   inbound_rule {
     protocol         = "tcp"
     port_range       = "80"
-    source_addresses = ["0.0.0.0/0", "::/0"]
+    source_addresses = [
+      var.inbound_home_ip,
+      var.inbound_static_ip
+    ]
   }
   outbound_rule {
     protocol              = "tcp"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -6,6 +6,14 @@ variable "ssh_key_fingerprint" {
   description = "Fingerprint of the public key stored on Digital Ocean"
 }
 
+variable "inbound_home_ip" {
+  description = "IP address of home network for inbound traffic"
+}
+
+variable "inbound_static_ip" {
+  description = "IP address from vpn provider for inbound traffic"
+}
+
 variable "region" {
   description = "Digital Ocean Region"
   default     = "nyc1"


### PR DESCRIPTION
Created inbound firewall rules to only allow traffic from a home network and a static IP granted by a VPN provider. Also added a `webserver` tag to the droplet.